### PR TITLE
Attempt to bump from Chapel 1.16.0 to 1.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Build Status](https://travis-ci.org/cyber-dojo-languages/chapel.svg?branch=master)
 
-[Version=1.16.0](https://github.com/cyber-dojo-languages/chapel/blob/master/check_version.sh)
+[Version=1.18.0](https://github.com/cyber-dojo-languages/chapel/blob/master/check_version.sh)
 
 ![cyber-dojo.org home page](https://github.com/cyber-dojo/cyber-dojo/blob/master/shared/home_page_snapshot.png)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM  cyberdojofoundation/alpine_glibc
 LABEL maintainer=bradcray@gmail.com
 
-ENV CHPL_VERSION 1.16.0
+ENV CHPL_VERSION 1.18.0
 ENV CHPL_HOME /opt/chapel/chapel-${CHPL_VERSION}
 ENV PATH ${PATH}:${CHPL_HOME}/bin/linux64:${CHPL_HOME}/util
 


### PR DESCRIPTION
I simply replaced the version numbers and am hoping everything
should "just work".  (I don't believe anything significant has
changed about our build system, so hopefully so).