### PR TITLE
Bump version to 1.20; update path to include processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 ![Build Status](https://travis-ci.org/cyber-dojo-languages/chapel.svg?branch=master)
 
-[Version=1.18.0](https://github.com/cyber-dojo-languages/chapel/blob/master/check_version.sh)
+[Version=1.20.0](https://github.com/cyber-dojo-languages/chapel/blob/master/check_version.sh)
 
 ![cyber-dojo.org home page](https://github.com/cyber-dojo/cyber-dojo/blob/master/shared/home_page_snapshot.png)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,9 @@
 FROM cyberdojofoundation/alpine_glibc
 LABEL maintainer=bradcray@gmail.com
 
-ENV CHPL_VERSION 1.18.0
+ENV CHPL_VERSION 1.20.0
 ENV CHPL_HOME /opt/chapel/chapel-${CHPL_VERSION}
-ENV PATH ${PATH}:${CHPL_HOME}/bin/linux64:${CHPL_HOME}/util
+ENV PATH ${PATH}:${CHPL_HOME}/bin/linux64-x86_64:${CHPL_HOME}/util
 
 RUN \
 apk update && \


### PR DESCRIPTION
This is essentially a repeat of what I did for 1.18, so hopefully will work similarly well.
While here, I also updated the PATH to include the processor type.  At some point,
we started being a bit more careful about bin/ directories and while the old path
should still work, this is more precise and should avoid a warning.
