### PR TITLE
Update Chapel to 1.25.0

### DIFF
--- a/check_version.sh
+++ b/check_version.sh
@@ -6,7 +6,7 @@ readonly JSON=`cat docker/image_name.json`
 readonly IMAGE_NAME="${BASH_REMATCH[1]}"
 
 readonly MY_DIR="$( cd "$( dirname "${0}" )" && pwd )"
-readonly EXPECTED=1.23.0
+readonly EXPECTED=1.25.0
 readonly ACTUAL=$(docker run --rm -it ${IMAGE_NAME} sh -c 'chpl --version')
 
 if echo "${ACTUAL}" | grep -q "${EXPECTED}"; then

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --update coreutils bash tar file
 
 LABEL maintainer=bradcray@gmail.com
 
-ENV CHPL_VERSION 1.23.0
+ENV CHPL_VERSION 1.25.0
 ENV CHPL_HOME /opt/chapel/chapel-${CHPL_VERSION}
 ENV PATH ${PATH}:${CHPL_HOME}/bin/linux64-x86_64:${CHPL_HOME}/util
 

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,7 +1,7 @@
 FROM cyberdojofoundation/alpine_glibc:7becbb4
 LABEL maintainer=bradcray@gmail.com
 
-ENV CHPL_VERSION 1.23.0
+ENV CHPL_VERSION 1.25.0
 ENV CHPL_HOME /opt/chapel/chapel-${CHPL_VERSION}
 ENV PATH ${PATH}:${CHPL_HOME}/bin/linux64-x86_64:${CHPL_HOME}/util
 


### PR DESCRIPTION
This is a bigger change than past releases because we've switched
Chapel to use its LLVM back-end by default now.  But hopefully Docker
will insulate cyber-dojo from having to worry about this at all.  If
not, we'll sort it out.
